### PR TITLE
fix: category 재설계 #76

### DIFF
--- a/core/network/src/main/java/com/easyhz/noffice/core/network/model/response/organization/OrganizationInformationResponse.kt
+++ b/core/network/src/main/java/com/easyhz/noffice/core/network/model/response/organization/OrganizationInformationResponse.kt
@@ -6,6 +6,6 @@ data class OrganizationInformationResponse(
     val leaderCount: Int,
     val participantCount: Int,
     val profileImage: String,
-    val categories: List<String>,
+    val categories: List<Int>,
     val isPending: Boolean,
 )

--- a/data/organization/src/main/java/com/easyhz/noffice/data/organization/mapper/OrganizationMapper.kt
+++ b/data/organization/src/main/java/com/easyhz/noffice/data/organization/mapper/OrganizationMapper.kt
@@ -2,6 +2,7 @@ package com.easyhz.noffice.data.organization.mapper
 
 import com.easyhz.noffice.core.model.organization.Organization
 import com.easyhz.noffice.core.model.organization.OrganizationInformation
+import com.easyhz.noffice.core.model.organization.category.Category
 import com.easyhz.noffice.core.model.organization.member.MemberType
 import com.easyhz.noffice.core.model.organization.member.mapMemberCounts
 import com.easyhz.noffice.core.network.model.response.organization.OrganizationCapsuleResponse
@@ -17,7 +18,7 @@ internal fun OrganizationResponse.toModel(): Organization = Organization(
 internal fun OrganizationInformationResponse.toModel(): OrganizationInformation = OrganizationInformation(
     id = this.organizationId,
     name = this.organizationName,
-    category = this.categories,
+    category = this.categories.map { Category(id = it, title = "", isSelected = false ) },
     profileImageUrl = this.profileImage,
     members = mapMemberCounts(MemberType.LEADER to leaderCount, MemberType.MEMBER to participantCount),
     hasStandbyMember = this.isPending

--- a/feature/organization/src/main/java/com/easyhz/noffice/feature/organization/component/detail/DetailHeader.kt
+++ b/feature/organization/src/main/java/com/easyhz/noffice/feature/organization/component/detail/DetailHeader.kt
@@ -79,7 +79,7 @@ internal fun DetailHeader(
                 ) {
                     organizationInformation.category.forEach {
                         NofficeChip(
-                            text = it,
+                            text = it.title,
                             selectState = ChipState.Picked,
                             chipStyles = ChipStyles(
                                 unSelected = OrganizationChipStyle,

--- a/feature/organization/src/main/java/com/easyhz/noffice/feature/organization/screen/detail/OrganizationDetailViewModel.kt
+++ b/feature/organization/src/main/java/com/easyhz/noffice/feature/organization/screen/detail/OrganizationDetailViewModel.kt
@@ -7,14 +7,18 @@ import androidx.paging.PagingData
 import androidx.paging.cachedIn
 import com.easyhz.noffice.core.common.base.BaseViewModel
 import com.easyhz.noffice.core.common.error.handleError
+import com.easyhz.noffice.core.model.organization.OrganizationInformation
 import com.easyhz.noffice.core.model.organization.announcement.OrganizationAnnouncement
+import com.easyhz.noffice.core.model.organization.category.Category
 import com.easyhz.noffice.domain.organization.usecase.announcement.FetchAnnouncementsByOrganizationUseCase
+import com.easyhz.noffice.domain.organization.usecase.category.FetchCategoriesUseCase
 import com.easyhz.noffice.domain.organization.usecase.organization.FetchOrganizationInfoUseCase
 import com.easyhz.noffice.feature.organization.contract.detail.DetailIntent
 import com.easyhz.noffice.feature.organization.contract.detail.DetailSideEffect
 import com.easyhz.noffice.feature.organization.contract.detail.DetailState
 import com.easyhz.noffice.feature.organization.contract.detail.DetailState.Companion.updateOrganizationName
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -24,12 +28,15 @@ import javax.inject.Inject
 @HiltViewModel
 class OrganizationDetailViewModel @Inject constructor(
     private val fetchOrganizationInfoUseCase: FetchOrganizationInfoUseCase,
+    private val fetchCategoriesUseCase: FetchCategoriesUseCase,
     private val fetchAnnouncementsByOrganizationUseCase: FetchAnnouncementsByOrganizationUseCase
 ) : BaseViewModel<DetailState, DetailIntent, DetailSideEffect>(
     initialState = DetailState.init()
 ) {
     private val _announcementState : MutableStateFlow<PagingData<OrganizationAnnouncement>> = MutableStateFlow(value = PagingData.empty())
     val announcementState: MutableStateFlow<PagingData<OrganizationAnnouncement>> get() = _announcementState
+
+    private var categoryList = MutableStateFlow<List<Category>>(value = emptyList())
 
     override fun handleIntent(intent: DetailIntent) {
         when (intent) {
@@ -57,23 +64,48 @@ class OrganizationDetailViewModel @Inject constructor(
 
     private fun initScreen(id: Int, name: String) {
         reduce { updateOrganizationName(name) }
-        fetchData(id)
+        initData(id)
     }
 
-    // FIXME
-    private fun fetchData(id: Int) = viewModelScope.launch {
-        fetchOrganizationInfoUseCase.invoke(id).onSuccess {
+    private fun initData(id: Int) = viewModelScope.launch {
+        val categoriesDeferred = async { fetchCategories() }
+        val organizationInfoDeferred = async { fetchOrganizationInfo(id) }
+
+        val categoriesResult = categoriesDeferred.await()
+        val organizationInfoResult = organizationInfoDeferred.await()
+
+        categoriesResult.onSuccess { categories ->
+            categoryList.value = categories
+        }.onFailure {
+            Log.d(this.javaClass.name, "fetchCategories - ${it.message}")
+            showSnackBar(it.handleError())
+            navigateToUp()
+            return@launch
+        }
+
+        organizationInfoResult.onSuccess { organizationInfo ->
+            val info = organizationInfo.copy(
+                category = categoryList.value.filter { it.id == organizationInfo.id }
+            )
             reduce {
                 copy(
-                    organizationInformation = it,
+                    organizationInformation = info,
                     isLoading = false
                 )
             }
-            fetchAnnouncements(it.id)
+            fetchAnnouncements(organizationInfo.id)
         }.onFailure {
             Log.d(this.javaClass.name, "fetchData - ${it.message}")
             showSnackBar(it.handleError())
         }
+    }
+
+    private suspend fun fetchCategories(): Result<List<Category>> {
+        return fetchCategoriesUseCase.invoke(Unit)
+    }
+
+    private suspend fun fetchOrganizationInfo(id: Int): Result<OrganizationInformation> {
+        return fetchOrganizationInfoUseCase.invoke(id)
     }
 
     private suspend fun fetchAnnouncements(organizationId: Int) {


### PR DESCRIPTION
## 🚀 Related Issue

close: #76 

## 📌 Tasks

- category 로 인한 빌드 오류 수정하였습니다.

## 📝 Details

- 조직 정보 화면에서 조직 정보를 받아올 때 카테고리를 id로 넘겨주기 때문에 카테고리를 얻은 후에야 조직 정보를 나타낼 수 있습니다.
-> 그래서 조직 정보와 카테고리는 비동기로 불러오고, `async` , `await` 를 활용하여  두 요청이 완료된 후에 로직을 처리하도록 변경하였습니다.

## 📚 Remarks

> Points or opinions to share teams

- 
- 