### PR TITLE
fix: 쿼리 파라미터 `memberId` 제거 #85

### DIFF
--- a/core/network/src/main/java/com/easyhz/noffice/core/network/api/organization/OrganizationService.kt
+++ b/core/network/src/main/java/com/easyhz/noffice/core/network/api/organization/OrganizationService.kt
@@ -22,7 +22,6 @@ interface OrganizationService {
     /* 가입된 조직 페이징 조회 */
     @GET("/api/v1/organizations")
     suspend fun fetchOrganizations(
-        @Query("memberId") memberId: Int,
         @Query("page") page: Int,
         @Query("size") size: Int = 10,
         @Query("sort") sort: List<String>
@@ -31,7 +30,6 @@ interface OrganizationService {
     /* 조직 생성 */
     @POST("/api/v1/organizations")
     suspend fun createOrganization(
-        @Query("memberId") memberId: Int,
         @Body body: OrganizationCreationRequest
     ): NofficeResult<OrganizationResponse>
 
@@ -39,14 +37,12 @@ interface OrganizationService {
     @GET("/api/v1/organizations/{organizationId}")
     suspend fun fetchOrganizationInfo(
         @Path("organizationId") organizationId: Int,
-        @Query("memberId") memberId: Int = 2 /* FIXME */,
     ): NofficeResult<OrganizationInformationResponse>
 
     /* 조직별 노티 페이징 조회 */
     @GET("/api/v1/organizations/{organizationId}/announcements")
     suspend fun fetchAnnouncementsByOrganization(
         @Path("organizationId") organizationId: Int,
-        @Query("memberId") memberId: Int,
         @Query("page") page: Int,
         @Query("size") size: Int = 10,
         @Query("sort") sort: List<String>
@@ -62,6 +58,5 @@ interface OrganizationService {
     @POST("/api/v1/organizations/{organizationId}/join")
     suspend fun joinOrganization(
         @Path("organizationId") organizationId: Int,
-        @Query("memberId") memberId: Int,
     ): NofficeResult<OrganizationJoinResponse>
 }

--- a/data/organization/src/main/java/com/easyhz/noffice/data/organization/pagingsource/OrganizationAnnouncementPagingSource.kt
+++ b/data/organization/src/main/java/com/easyhz/noffice/data/organization/pagingsource/OrganizationAnnouncementPagingSource.kt
@@ -8,8 +8,7 @@ import com.easyhz.noffice.core.network.model.response.announcement.AnnouncementI
 class OrganizationAnnouncementPagingSource(
     private val organizationService: OrganizationService,
     private val organizationId: Int,
-    private val memberId: Int?,
-): PagingSource<Int, AnnouncementItem>() {
+) : PagingSource<Int, AnnouncementItem>() {
     override fun getRefreshKey(state: PagingState<Int, AnnouncementItem>): Int? {
         return state.anchorPosition?.let { anchorPosition ->
             state.closestPageToPosition(anchorPosition)?.run {
@@ -21,30 +20,27 @@ class OrganizationAnnouncementPagingSource(
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, AnnouncementItem> {
         val page = params.key ?: START_PAGE
         val loadSize = params.loadSize
-        return memberId?.let { id ->
-            organizationService.fetchAnnouncementsByOrganization(
-                organizationId = organizationId,
-                memberId = id,
-                page = page,
-                size = loadSize,
-                sort = emptyList() /* FIXME */
-            ).fold(
-                onSuccess = {
-                    LoadResult.Page(
-                        data = it.data.content,
-                        prevKey = null,
-                        nextKey = if (it.data.content.size < loadSize) null else page + 1
-                    )
-                },
-                onFailure = {
-                    LoadResult.Error(it)
-                }
-            )
-        } ?: LoadResult.Page(data = emptyList(), prevKey = null, nextKey = null)
+        return organizationService.fetchAnnouncementsByOrganization(
+            organizationId = organizationId,
+            page = page,
+            size = loadSize,
+            sort = emptyList() /* FIXME */
+        ).fold(
+            onSuccess = {
+                LoadResult.Page(
+                    data = it.data.content,
+                    prevKey = null,
+                    nextKey = if (it.data.content.size < loadSize) null else page + 1
+                )
+            },
+            onFailure = {
+                LoadResult.Error(it)
+            }
+        )
     }
 
 
-        companion object {
+    companion object {
         const val PAGE_SIZE = 10
         private const val START_PAGE = 0
     }

--- a/data/organization/src/main/java/com/easyhz/noffice/data/organization/pagingsource/OrganizationPagingSource.kt
+++ b/data/organization/src/main/java/com/easyhz/noffice/data/organization/pagingsource/OrganizationPagingSource.kt
@@ -7,8 +7,7 @@ import com.easyhz.noffice.core.network.model.response.organization.OrganizationC
 
 class OrganizationPagingSource(
     private val organizationService: OrganizationService,
-    private val memberId: Int?
-):PagingSource<Int, OrganizationCapsuleResponse>() {
+): PagingSource<Int, OrganizationCapsuleResponse>() {
     override fun getRefreshKey(state: PagingState<Int, OrganizationCapsuleResponse>): Int? {
         return state.anchorPosition?.let { anchorPosition ->
             state.closestPageToPosition(anchorPosition)?.run {
@@ -20,26 +19,24 @@ class OrganizationPagingSource(
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, OrganizationCapsuleResponse> {
         val page = params.key ?: START_PAGE
         val loadSize = params.loadSize
-        return memberId?.let { id ->
-            organizationService.fetchOrganizations(
-                memberId = id,
-                page = page,
-                size = loadSize,
-                sort = emptyList() /* FIXME */
-            ).fold(
-                onSuccess = {
-                    LoadResult.Page(
-                        data = it.data.content,
-                        prevKey = null,
-                        nextKey = if (it.data.content.size < loadSize) null else page + 1
-                    )
-                },
-                onFailure = {
-                    LoadResult.Error(it)
-                }
-            )
-        } ?: LoadResult.Page(data = emptyList(), prevKey = null, nextKey = null)
+        return organizationService.fetchOrganizations(
+            page = page,
+            size = loadSize,
+            sort = emptyList() /* FIXME */
+        ).fold(
+            onSuccess = {
+                LoadResult.Page(
+                    data = it.data.content,
+                    prevKey = null,
+                    nextKey = if (it.data.content.size < loadSize) null else page + 1
+                )
+            },
+            onFailure = {
+                LoadResult.Error(it)
+            }
+        )
     }
+
     companion object {
         const val PAGE_SIZE = 10
         private const val START_PAGE = 0

--- a/data/organization/src/main/java/com/easyhz/noffice/data/organization/repository/organization/OrganizationRepository.kt
+++ b/data/organization/src/main/java/com/easyhz/noffice/data/organization/repository/organization/OrganizationRepository.kt
@@ -12,7 +12,7 @@ interface OrganizationRepository {
     suspend fun fetchOrganizations(): Flow<PagingData<Organization>>
     suspend fun createOrganization(param: OrganizationCreationParam): Result<Organization>
     suspend fun fetchOrganizationInfo(organizationId: Int): Result<OrganizationInformation>
-    suspend fun fetchAnnouncementsByOrganization(organizationId: Int, memberId: Int): Flow<PagingData<OrganizationAnnouncement>>
+    suspend fun fetchAnnouncementsByOrganization(organizationId: Int): Flow<PagingData<OrganizationAnnouncement>>
     suspend fun updateOrganizationCategory(organizationId: Int, category: List<Int>): Result<Category>
     suspend fun joinOrganization(organizationId: Int): Result<Unit>
 }

--- a/domain/organization/src/main/java/com/easyhz/noffice/domain/organization/usecase/announcement/FetchAnnouncementsByOrganizationUseCase.kt
+++ b/domain/organization/src/main/java/com/easyhz/noffice/domain/organization/usecase/announcement/FetchAnnouncementsByOrganizationUseCase.kt
@@ -9,7 +9,7 @@ import javax.inject.Inject
 class FetchAnnouncementsByOrganizationUseCase @Inject constructor(
     private val organizationRepository: OrganizationRepository
 ) {
-    suspend operator fun invoke(organizationId: Int, memberId: Int): Flow<PagingData<OrganizationAnnouncement>> {
-        return organizationRepository.fetchAnnouncementsByOrganization(organizationId, memberId)
+    suspend operator fun invoke(organizationId: Int): Flow<PagingData<OrganizationAnnouncement>> {
+        return organizationRepository.fetchAnnouncementsByOrganization(organizationId)
     }
 }

--- a/feature/organization/src/main/java/com/easyhz/noffice/feature/organization/screen/detail/OrganizationDetailViewModel.kt
+++ b/feature/organization/src/main/java/com/easyhz/noffice/feature/organization/screen/detail/OrganizationDetailViewModel.kt
@@ -109,7 +109,7 @@ class OrganizationDetailViewModel @Inject constructor(
     }
 
     private suspend fun fetchAnnouncements(organizationId: Int) {
-        fetchAnnouncementsByOrganizationUseCase(organizationId, 1).distinctUntilChanged()
+        fetchAnnouncementsByOrganizationUseCase(organizationId).distinctUntilChanged()
             .cachedIn(viewModelScope).collectLatest {
                 _announcementState.value = it
             }


### PR DESCRIPTION
## 🚀 Related Issue

close: #85 

## 📌 Tasks

- api 임시 쿼리 파라미터 `memberId` 일괄 제거


## 📝 Details

- api 의 임시 쿼리 파라미터 `memberId`를 일괄 제거하였습니다
- 그에 따른 다른 로직도 일부 수정하였습니다

## 📚 Remarks

> Points or opinions to share teams

- 
- 