### PR TITLE
fix: 버튼 활성화 수정 #98

### DIFF
--- a/feature/announcement/src/main/java/com/easyhz/noffice/feature/announcement/screen/creation/CreationViewModel.kt
+++ b/feature/announcement/src/main/java/com/easyhz/noffice/feature/announcement/screen/creation/CreationViewModel.kt
@@ -45,10 +45,12 @@ class CreationViewModel @Inject constructor(
 
     private fun onChangeTitleTextValue(newText: String) {
         reduce { copy(title = newText) }
+        setEnabledButton()
     }
 
     private fun onChangeContentTextValue(newText: TextFieldValue) {
         reduce { copy(content = newText) }
+        setEnabledButton()
     }
 
     private fun onClickOptionButton(option: Options) {
@@ -125,6 +127,7 @@ class CreationViewModel @Inject constructor(
         val isContentNotBlank = currentState.content.text.isNotBlank()
 
         val buttonEnabled = isOptionSelected && isTitleNotBlank && isContentNotBlank
+        if (currentState.enabledButton == buttonEnabled) return
         reduce { copy(enabledButton = buttonEnabled) }
     }
 }


### PR DESCRIPTION
## 🚀 Related Issue

close: #98 

## 📌 Tasks

- `제목`, `내용`이 채워진 채로 선택 항목을 선택해야 버튼이 활성화 되게 되어있는 이슈를 고쳤습니다

## 📝 Details

- `제목`, `내용`이 뒤에 채워져도 버튼이 활성화 되도록 고쳤습니다

## 📚 Remarks

> Points or opinions to share teams

- 
- 