### PR TITLE
fix: place badge weight 수정 (#139)

### DIFF
--- a/feature/organization/src/main/java/com/easyhz/noffice/feature/organization/component/detail/AnnouncementCard.kt
+++ b/feature/organization/src/main/java/com/easyhz/noffice/feature/organization/component/detail/AnnouncementCard.kt
@@ -68,7 +68,7 @@ internal fun AnnouncementCard(
 
             announcement.place.takeIf { !it.isNullOrBlank() }?.run {
                 Badge(
-                    modifier = Modifier.weight(1f),
+                    modifier = Modifier.weight(1f, false),
                     string = this,
                     iconId = Options.PLACE.iconId
                 )


### PR DESCRIPTION
## 🚀 Related Issue

close: #139 

## 📌 Tasks

- place badge

## 📝 Details
- `weight` 의 `fill` 옵션을 수정하였습니다
-> `Modifier.weight(1f)` 를 `Modifer.weight(1f, false)`로 바꾸어주었습니다.

## 📚 Remarks

> Points or opinions to share teams

- 
- 